### PR TITLE
add snooze button and show list of running timers in break screen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Build Release
       if: startsWith(github.ref, 'refs/tags/')
       run: |
-        zig build all-targets -Doptimize=ReleaseSafe --verbose
+        zig build all-targets -Doptimize=ReleaseFast --verbose
 
     - name: Release
       uses: softprops/action-gh-release@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     # source: https://github.com/libsdl-org/SDL/blob/f32575dfabecac37892e3abfe31b08b9e348a9d7/docs/README-linux.md
     - name: Install SDL2 Linux dependencies
       run: |
-        sudo apt-get install build-essential make \
+        sudo apt-get update && apt-get install build-essential make \
         pkg-config libasound2-dev libpulse-dev \
         libaudio-dev libjack-dev libsndio-dev libx11-dev libxext-dev \
         libxrandr-dev libxcursor-dev libxfixes-dev libxi-dev libxss-dev \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     # source: https://github.com/libsdl-org/SDL/blob/f32575dfabecac37892e3abfe31b08b9e348a9d7/docs/README-linux.md
     - name: Install SDL2 Linux dependencies
       run: |
-        sudo apt-get update && apt-get install build-essential make \
+        sudo apt-get update && sudo apt-get install build-essential make \
         pkg-config libasound2-dev libpulse-dev \
         libaudio-dev libjack-dev libsndio-dev libx11-dev libxext-dev \
         libxrandr-dev libxcursor-dev libxfixes-dev libxi-dev libxss-dev \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,8 @@ jobs:
     # source: https://github.com/libsdl-org/SDL/blob/f32575dfabecac37892e3abfe31b08b9e348a9d7/docs/README-linux.md
     - name: Install SDL2 Linux dependencies
       run: |
-        sudo apt-get install build-essential git make \
-        pkg-config cmake ninja-build gnome-desktop-testing libasound2-dev libpulse-dev \
+        sudo apt-get install build-essential make \
+        pkg-config libasound2-dev libpulse-dev \
         libaudio-dev libjack-dev libsndio-dev libx11-dev libxext-dev \
         libxrandr-dev libxcursor-dev libxfixes-dev libxi-dev libxss-dev \
         libxkbcommon-dev libdrm-dev libgbm-dev libgl1-mesa-dev libgles2-mesa-dev \

--- a/src/main.zig
+++ b/src/main.zig
@@ -500,7 +500,11 @@ pub fn main() !void {
                                     imgui.igText(try state.tprint("Times snoozed: {d}", .{state.snooze_times}));
                                 }
 
-                                if (state.user_settings.is_activity_break_enabled) {
+                                if (state.snooze_activity_break_timer) |*snooze_timer| {
+                                    imgui.igText(try state.tprint("Snooze timer over in: {s}", .{
+                                        state.user_settings.snooze_duration_or_default().diff(snooze_timer.read()),
+                                    }));
+                                } else if (state.user_settings.is_activity_break_enabled) {
                                     const time_till_activity_break_format = "Time till activity break: {s}";
                                     if (state.is_user_mouse_active) {
                                         imgui.igText(try state.tprint(time_till_activity_break_format, .{

--- a/src/main.zig
+++ b/src/main.zig
@@ -292,12 +292,12 @@ pub fn main() !void {
             sdl.SDL_Delay(minimized_delay);
 
             const renderer = state.window.renderer;
-            _ = sdl.SDL_SetRenderDrawColor(renderer, 20, 20, 20, 0);
+            // _ = sdl.SDL_SetRenderDrawColor(renderer, 20, 20, 20, 0);
             // _ = sdl.SDL_SetRenderDrawColor(renderer, 200, 200, 200, 0);
-            _ = sdl.SDL_RenderClear(renderer);
+            // _ = sdl.SDL_RenderClear(renderer);
             imgui.igRender();
             imgui.ImGui_ImplSDLRenderer2_RenderDrawData(@ptrCast(imgui.igGetDrawData()), @ptrCast(renderer));
-            // sdl.SDL_RenderPresent(renderer);
+            _ = sdl.SDL_RenderFlush(renderer);
             continue;
         }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -120,7 +120,7 @@ pub fn main() !void {
         .mode = .regular,
         .window = app_window,
         .user_settings = user_settings,
-        .time_till_next_state = try std.time.Timer.start(),
+        .activity_timer = try std.time.Timer.start(),
         .temp_allocator = std.heap.ArenaAllocator.init(allocator),
     };
     defer {
@@ -134,7 +134,6 @@ pub fn main() !void {
     // state.user_settings.default_break_time = Duration.init(5 * time.ns_per_s);
 
     var has_quit = false;
-    var todo_checkbox: bool = false;
     while (!has_quit) {
         imgui.igSetCurrentContext(state.window.imgui_context);
         _ = state.temp_allocator.reset(.retain_capacity);
@@ -217,6 +216,7 @@ pub fn main() !void {
                 diff.y >= 5)
             {
                 state.time_since_last_input = try std.time.Timer.start();
+                state.is_user_mouse_active = true;
             }
 
             if (state.mode == .regular) {
@@ -226,10 +226,10 @@ pub fn main() !void {
                     const inactivity_duration = 5 * std.time.ns_per_min;
                     if (time_since_last_input.read() > inactivity_duration) {
                         state.is_user_mouse_active = false;
-                        state.time_till_next_state.reset();
+                        state.activity_timer.reset();
                     }
                 } else {
-                    state.time_till_next_state.reset();
+                    state.activity_timer.reset();
                     state.is_user_mouse_active = false;
                 }
             }
@@ -247,7 +247,7 @@ pub fn main() !void {
                         }
                     },
                     .taking_break => {
-                        const time_active_in_ns = state.time_till_next_state.read();
+                        const time_active_in_ns = state.activity_timer.read();
                         const time_till_break_over = state.user_settings.break_time_or_default().diff(time_active_in_ns);
                         if (time_till_break_over.nanoseconds <= 0) {
                             state.change_mode(.regular);
@@ -283,7 +283,7 @@ pub fn main() !void {
         if (state.mode == .regular and sdl.SDL_GetWindowFlags(state.window.window) & sdl.SDL_WINDOW_MINIMIZED != 0) {
             const minimized_delay: u32 = switch (builtin.os.tag) {
                 .windows => 100, // Above 1000ms feels unresponsive when you unminimize it
-                .macos => 2000, // Mac OSX feels fine at 2000ms to bring it back up,
+                .macos => 1000, // Mac OSX feels fine at 1000ms to bring it back up,
                 .linux => 800, // Kbuntu opens up, might be a blank ugly transparent screen for a bit, but then pop-in
                 else => 100, // Default to 100ms for anything else that's untested
             };
@@ -384,18 +384,20 @@ pub fn main() !void {
                                         else => {},
                                     }
 
-                                    // List displays
+                                    // List displays by name (if supported by operating system)
+                                    // - Windows: "0: MSI G241", "1: UGREEN"
+                                    // - MacOS: "0: 0" and "1: 1"
                                     {
                                         const display_count_or_err: u32 = @intCast(sdl.SDL_GetNumVideoDisplays());
                                         state.ui.options_metadata.display_names_buf.len = 0;
                                         if (display_count_or_err >= 1) {
                                             const display_count: u32 = @intCast(display_count_or_err);
                                             for (0..display_count) |display_index| {
-                                                const name = sdl.SDL_GetDisplayName(@intCast(display_index));
-                                                if (name == null) {
+                                                const name_c_str = sdl.SDL_GetDisplayName(@intCast(display_index));
+                                                if (name_c_str == null) {
                                                     continue;
                                                 }
-                                                try state.ui.options_metadata.display_names_buf.writer().print("{s}\x00", .{name});
+                                                try state.ui.options_metadata.display_names_buf.writer().print("{d}: {s}\x00", .{ display_index, name_c_str });
                                             }
                                         }
                                     }
@@ -489,19 +491,30 @@ pub fn main() !void {
                             // Bottom-left-corner
                             {
                                 imgui.igSetNextWindowPos(.{ .x = 0, .y = viewport_size.y }, imgui.ImGuiCond_Always, .{ .x = 0, .y = 1 });
-                                _ = imgui.igBegin("general-bottom-left-corner", null, imgui_default_window_flags);
+                                _ = imgui.igBegin("general-bottom-left-corner", null, imgui_default_window_flags | imgui.ImGuiWindowFlags_AlwaysAutoResize);
                                 defer imgui.igEnd();
 
+                                if (state.snooze_times > 0) {
+                                    imgui.igText(try state.tprint("Times snoozed: {d}", .{state.snooze_times}));
+                                }
+
                                 if (state.user_settings.is_activity_break_enabled) {
-                                    imgui.igText(try state.tprint("Time till activity break: {s}", .{
-                                        state.user_settings.time_till_break_or_default().diff(state.time_till_next_state.read()),
-                                    }));
+                                    const time_till_activity_break_format = "Time till activity break: {s}";
+                                    if (state.is_user_mouse_active) {
+                                        imgui.igText(try state.tprint(time_till_activity_break_format, .{
+                                            state.user_settings.time_till_break_or_default().diff(state.activity_timer.read()),
+                                        }));
+                                    } else {
+                                        imgui.igText(try state.tprint(time_till_activity_break_format, .{
+                                            "(No mouse activity)",
+                                        }));
+                                    }
                                 }
 
                                 // DEBUG: Add debug info
                                 if (builtin.mode == .Debug) {
                                     {
-                                        const time_in_seconds = @divFloor(state.time_till_next_state.read(), std.time.ns_per_s);
+                                        const time_in_seconds = @divFloor(state.activity_timer.read(), std.time.ns_per_s);
                                         imgui.igText("DEBUG: Time using computer: %d", time_in_seconds);
                                     }
                                     if (state.time_since_last_input) |*time_since_last_input| {
@@ -759,51 +772,27 @@ pub fn main() !void {
                     }
                 },
                 .taking_break => {
+                    var has_triggered_exiting_break_mode = false;
+                    const required_esc_presses = 30;
+
+                    // Top-Left
                     {
                         imgui.igSetNextWindowPos(viewport_pos, 0, .{ .x = 0, .y = 0 });
-                        imgui.igSetNextWindowSize(.{ .x = viewport_size.x, .y = 0 }, 0);
-                        _ = imgui.igBegin("break", null, imgui_default_window_flags);
+                        _ = imgui.igBegin("break-top-left", null, imgui_default_window_flags | imgui.ImGuiWindowFlags_AlwaysAutoResize);
                         defer imgui.igEnd();
 
                         imgui.igText(try state.tprint("Time till break is over: {s}", .{
-                            state.user_settings.break_time_or_default().diff(state.time_till_next_state.read()),
+                            state.user_settings.break_time_or_default().diff(state.activity_timer.read()),
                         }));
                     }
 
+                    // Top-Right
                     {
-                        imgui.igSetNextWindowPos(.{ .x = viewport_size.x / 2, .y = viewport_size.y / 2 }, imgui.ImGuiCond_Always, .{ .x = 0.5, .y = 0.5 });
-                        _ = imgui.igBegin("break-center", null, imgui_default_window_flags);
+                        imgui.igSetNextWindowPos(.{ .x = viewport_size.x, .y = 0 }, imgui.ImGuiCond_Always, .{ .x = 1, .y = 0 });
+                        _ = imgui.igBegin("break-top-right", null, imgui_default_window_flags | imgui.ImGuiWindowFlags_AlwaysAutoResize);
                         defer imgui.igEnd();
 
-                        imgui.igText("(In a future version we want to add the ability to add a daily todo list here)");
-                        if (builtin.mode == .Debug) {
-                            imgui.igText("Daily To-Do List");
-                            _ = imgui.igCheckbox("Todo Item One", &todo_checkbox);
-                            _ = imgui.igCheckbox("Todo Item Two", &todo_checkbox);
-                            _ = imgui.igCheckbox("Todo Item Three", &todo_checkbox);
-                        }
-                    }
-
-                    {
-                        imgui.igSetNextWindowPos(.{ .x = viewport_size.x, .y = viewport_size.y }, imgui.ImGuiCond_Always, .{ .x = 1, .y = 1 });
-                        _ = imgui.igBegin("break-bottom-right-corner", null, imgui_default_window_flags | imgui.ImGuiWindowFlags_AlwaysAutoResize);
-                        defer imgui.igEnd();
-
-                        if (state.break_mode.held_down_timer) |*exit_timer| {
-                            imgui.igText(
-                                try state.tprint("Will exit in: {s}", .{state.user_settings.exit_time_or_default().diff(exit_timer.read())}),
-                            );
-                        }
-
-                        var has_triggered_exiting_break_mode = false;
-                        const required_esc_presses = 30;
-                        if (state.break_mode.esc_or_exit_presses > 1) {
-                            imgui.igText(
-                                try state.tprint("Presses until exit: {}/{}", .{ state.break_mode.esc_or_exit_presses, required_esc_presses }),
-                            );
-                        }
-
-                        if (imgui.igButtonEx("Exit", .{}, imgui.ImGuiButtonFlags_PressedOnClick)) {
+                        if (imgui.igButton("Exit", .{})) {
                             if (state.break_mode.held_down_timer == null) {
                                 state.break_mode.held_down_timer = try time.Timer.start();
                             }
@@ -816,20 +805,95 @@ pub fn main() !void {
                                 has_quit = true;
                             }
                         }
+                    }
 
-                        // Check if triggered exit break mode manually
+                    {
+                        imgui.igSetNextWindowPos(.{ .x = viewport_size.x / 2, .y = viewport_size.y / 2 }, imgui.ImGuiCond_Always, .{ .x = 0.5, .y = 0.5 });
+                        _ = imgui.igBegin("break-center", null, imgui_default_window_flags);
+                        defer imgui.igEnd();
+
+                        const has_active_timers = timercheck: {
+                            for (state.user_settings.timers.items) |*t| {
+                                switch (t.kind) {
+                                    .timer => {
+                                        if (t.timer_started == null or // If not using this timer, skip
+                                            t.timer_duration == null // If no duration configured, skip
+                                        ) {
+                                            continue;
+                                        }
+                                        break :timercheck true;
+                                    },
+                                    .alarm => @panic("TODO: Handle listing alarm"),
+                                }
+                            }
+                            break :timercheck false;
+                        };
+                        imgui.igText("It's time for a break. Get up, stretch your limbs a bit!");
+                        if (has_active_timers) {
+                            imgui.igNewLine();
+                            imgui.igText("Timers:");
+                            for (state.user_settings.timers.items) |*t| {
+                                switch (t.kind) {
+                                    .timer => {
+                                        // If not using this timer, skip
+                                        var timer_started = t.timer_started orelse continue;
+                                        // If no duration configured, skip
+                                        const timer_duration = t.timer_duration orelse continue;
+
+                                        // Show timer with time left
+                                        const duration_left = timer_duration.diff(timer_started.read());
+                                        imgui.igText(try state.tprint("{s} - {s}", .{ t.name.slice(), duration_left }));
+                                    },
+                                    .alarm => @panic("TODO: Handle listing alarm"),
+                                }
+                            }
+                        }
+                        // if (builtin.mode == .Debug) {
+                        //     imgui.igText("Daily To-Do List");
+                        //     _ = imgui.igCheckbox("Todo Item One", &todo_checkbox);
+                        //     _ = imgui.igCheckbox("Todo Item Two", &todo_checkbox);
+                        //     _ = imgui.igCheckbox("Todo Item Three", &todo_checkbox);
+                        // }
+                    }
+
+                    // Bottom-right
+                    {
+                        imgui.igSetNextWindowPos(.{ .x = viewport_size.x, .y = viewport_size.y }, imgui.ImGuiCond_Always, .{ .x = 1, .y = 1 });
+                        _ = imgui.igBegin("break-bottom-right-corner", null, imgui_default_window_flags | imgui.ImGuiWindowFlags_AlwaysAutoResize);
+                        defer imgui.igEnd();
+
                         if (state.break_mode.held_down_timer) |*exit_timer| {
-                            const exit_time_left = state.user_settings.exit_time_or_default().diff(exit_timer.read());
-                            if (exit_time_left.nanoseconds <= 0) {
+                            imgui.igText(
+                                try state.tprint("Will exit in: {s}", .{state.user_settings.exit_time_or_default().diff(exit_timer.read())}),
+                            );
+                        }
+
+                        if (state.break_mode.esc_or_exit_presses > 1) {
+                            imgui.igText(
+                                try state.tprint("Presses until exit: {}/{}", .{ state.break_mode.esc_or_exit_presses, required_esc_presses }),
+                            );
+                        }
+
+                        if (state.can_snooze()) {
+                            if (imgui.igButton("Snooze", .{})) {
+                                state.snooze();
                                 has_triggered_exiting_break_mode = true;
                             }
                         }
-                        if (state.break_mode.esc_or_exit_presses >= required_esc_presses) {
+                    }
+
+                    // Check if triggered exit break mode manually
+                    if (state.break_mode.held_down_timer) |*exit_timer| {
+                        const exit_time_left = state.user_settings.exit_time_or_default().diff(exit_timer.read());
+                        if (exit_time_left.nanoseconds <= 0) {
                             has_triggered_exiting_break_mode = true;
                         }
-                        if (has_triggered_exiting_break_mode) {
-                            state.change_mode(.regular);
-                        }
+                    }
+                    if (state.break_mode.esc_or_exit_presses >= required_esc_presses) {
+                        has_triggered_exiting_break_mode = true;
+                    }
+                    if (has_triggered_exiting_break_mode) {
+                        state.change_mode(.regular);
                     }
                 },
                 .incoming_break => {
@@ -841,6 +905,14 @@ pub fn main() !void {
                     imgui.igText("Break time in:");
                     if (state.time_till_next_timer_complete()) |time_till_break| {
                         imgui.igText(try state.tprint("{s}", .{time_till_break}));
+                    } else {
+                        imgui.igText(try state.tprint("", .{}));
+                    }
+                    if (state.can_snooze()) {
+                        if (imgui.igButton("Snooze", .{})) {
+                            state.snooze();
+                            state.change_mode(.regular);
+                        }
                     }
                 },
             }


### PR DESCRIPTION
- add snooze button (will trigger in 10m instead, todo: make this configurable)
- show list of running timers in break screen
- add "snooze times" counter to main UI (lost if application is closed currently)
- reduce MacOSX sleep timer when minimized from 2000ms to 1000ms
- fix bug where render queue would build up while minimized, we now just flush it to stop weird 2-8s hitching
- make timers related to task only make you have a 45 second break (todo: make this configurable in the future)
- update ci to do `sudo apt-get update` to resolve issues with certain packages not being found
- update ci to do a `ReleaseFast` build instead of `ReleaseSafe`