### PR TITLE
improve foreground performance and switch CI to mlugg/setup-zig for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,10 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Setup Zig
-      uses: goto-bus-stop/setup-zig@v2
+      # note(jae): 2024-09-15
+      # Uses download mirror first as preferred by Zig Foundation
+      # see: https://ziglang.org/news/migrate-to-self-hosting/
+      uses: mlugg/setup-zig@v1
       with:
         version: "0.13.0"
 


### PR DESCRIPTION
- Improve foreground performance
- switch CI to mlugg/setup-zig so downloading Zig prefers mirrors. The Zig Foundation would prefer if folks did this, see: https://ziglang.org/news/migrate-to-self-hosting/