### PR TITLE
add support for java game detection on Windows and Linux

### DIFF
--- a/src/App.zig
+++ b/src/App.zig
@@ -9,6 +9,7 @@ const imgui = @import("imgui");
 const Image = @import("Image.zig");
 const UserConfig = @import("UserConfig.zig");
 const Duration = @import("Duration.zig");
+const ProcessList = @import("ProcessList.zig");
 
 const Window = @import("Window.zig");
 
@@ -265,9 +266,10 @@ activity_timer: time.Timer,
 snooze_activity_break_timer: ?time.Timer = null,
 
 is_user_active: bool = false,
-
-process_check_timer: time.Timer,
 is_game_active: bool = false,
+
+process_list: ProcessList,
+process_check_timer: time.Timer,
 
 /// amount of times snooze button was hit
 snooze_times: u32 = 0,
@@ -319,6 +321,7 @@ pub fn init(allocator: std.mem.Allocator, user_settings: *UserSettings) !App {
         .tray = null,
         .user_settings = user_settings,
         .activity_timer = try std.time.Timer.start(),
+        .process_list = undefined, // Init after
         .process_check_timer = try std.time.Timer.start(),
         .ui = .{
             .ui_allocator = std.heap.ArenaAllocator.init(allocator),
@@ -348,6 +351,7 @@ pub fn deinit(app: *App) void {
     if (app.tray) |tray| {
         sdl.SDL_DestroyTray(tray);
     }
+    app.process_list.deinit();
     app.icon.deinit(allocator);
     app.user_settings.deinit(allocator);
     allocator.destroy(app.user_settings);

--- a/src/ProcessList.zig
+++ b/src/ProcessList.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const assert = std.debug.assert;
 const Dir = std.fs.Dir;
 const PlatformProcessList = switch (builtin.os.tag) {
     .windows => WindowsProcessList,
@@ -13,10 +14,20 @@ impl: PlatformProcessList = undefined,
 
 pub const is_supported = PlatformProcessList != DummyProcessList;
 
-pub fn open() OpenError!Self {
-    return .{
-        .impl = try .open(),
+pub fn init(self: *Self) !void {
+    self.* = .{
+        .impl = undefined,
     };
+    try self.impl.init();
+}
+
+pub fn deinit(self: *Self) void {
+    self.impl.deinit();
+    self.impl = undefined;
+}
+
+pub fn open(self: *Self, allocator: std.mem.Allocator) OpenError!void {
+    try self.impl.open(allocator);
 }
 
 pub fn next(self: *Self) !?Entry {
@@ -25,7 +36,6 @@ pub fn next(self: *Self) !?Entry {
 
 pub fn close(self: *Self) void {
     self.impl.close();
-    self.impl = undefined;
 }
 
 pub const Entry = struct {
@@ -39,6 +49,11 @@ pub const Entry = struct {
     /// - /var/home/USER/Documents/ZigProjects/desk-breaker/zig-out/bin/desk-breaker
     /// - /var/home/USER/.local/share/Steam/steamapps/common/Hollow Knight Silksong/Hollow Knight Silksong
     exe_filepath: []const u8,
+    /// (Optional) If the application is 'java' ('javaw' on Windows) will contain all the launch arguments.
+    ///
+    /// Linux:
+    /// - -Xms512m -Xmx4096m -Duser.language=en -Djava.library.path=/var/home/USER/.var/app/org.prismlauncher.PrismLauncher/data/PrismLauncher/libraries/org/slf4j/slf4j-api/2.0.17/slf4j-api-2.0.17.jar:/var/home/USER/.var/app/org.prismlauncher.PrismLauncher/data/PrismLauncher/libraries/com/mojang/minecraft/1.21.11/minecraft-1.21.11-client.jar org.prismlauncher.EntryPoint
+    jar_arguments: []const u8,
 };
 
 pub const OpenError = error{ AccessDenied, OutOfMemory, Unexpected };
@@ -46,39 +61,65 @@ pub const OpenError = error{ AccessDenied, OutOfMemory, Unexpected };
 // Based of example code here: https://learn.microsoft.com/en-us/windows/win32/psapi/enumerating-all-processes
 const WindowsProcessList = struct {
     const windows = std.os.windows;
+    iterator: Iterator = .empty,
 
-    /// For my personal use, I had around ~250 or so.
-    const MaxProcessList = 8192;
+    exe_filepath_buffer: [std.fs.max_path_bytes:0]u8,
+    processes_buffer: [8192]windows.DWORD, // NOTE(jae): Arbitrarily chose 8192, on my machine I'm apparently running ~250 processes usually.
+    wmi: Wmi,
 
-    processes: [MaxProcessList]windows.DWORD = undefined,
-    index: u32,
-    len: u32,
-    it_exe_filepath: [std.fs.max_path_bytes:0]u8 = undefined,
+    const Iterator = struct {
+        pub const empty: Iterator = .{
+            .allocator = undefined,
+            .index = 0,
+            .processes = &[0]windows.DWORD{},
+            .command_line_arguments = &[0]u8{},
+        };
+        allocator: std.mem.Allocator,
+        processes: []windows.DWORD,
+        index: u32,
+        command_line_arguments: []const u8,
+    };
 
-    fn open() OpenError!@This() {
-        var processes: [MaxProcessList]windows.DWORD = undefined;
-        const max_processes_len_in_bytes: windows.DWORD = processes.len * @sizeOf(windows.DWORD);
+    fn init(self: *@This()) !void {
+        self.* = .{
+            .iterator = .empty,
+            .exe_filepath_buffer = undefined,
+            .processes_buffer = undefined,
+            .wmi = .none,
+        };
+        try self.wmi.init();
+    }
+
+    fn deinit(self: *@This()) void {
+        self.wmi.deinit();
+        self.* = undefined;
+    }
+
+    fn open(self: *@This(), allocator: std.mem.Allocator) OpenError!void {
+        const process_buffer_in_bytes = self.processes_buffer.len * @sizeOf(windows.DWORD);
         var given_processes_len_in_bytes: windows.DWORD = 0;
-        if (K32EnumProcesses(&processes[0], max_processes_len_in_bytes, &given_processes_len_in_bytes) == 0)
+        if (kernel32.K32EnumProcesses(&self.processes_buffer[0], process_buffer_in_bytes, &given_processes_len_in_bytes) == 0)
             return windows.unexpectedError(windows.GetLastError());
         // From MDN: if lpcbNeeded equals cb (given), consider retrying the call with a larger array.
-        if (given_processes_len_in_bytes >= max_processes_len_in_bytes) {
+        if (given_processes_len_in_bytes >= process_buffer_in_bytes) {
             return error.OutOfMemory;
         }
-        return .{
+        const processes = self.processes_buffer[0 .. given_processes_len_in_bytes / @sizeOf(windows.DWORD)];
+        self.iterator = .{
+            .allocator = allocator,
             .processes = processes,
             .index = 0,
-            .len = given_processes_len_in_bytes / @sizeOf(windows.DWORD),
+            .command_line_arguments = &[0]u8{},
         };
     }
 
     fn next(self: *@This()) !?Entry {
-        while (self.index < self.len) : (self.index += 1) {
-            const process_id = self.processes[self.index];
+        while (self.iterator.index < self.iterator.processes.len) : (self.iterator.index += 1) {
+            const process_id = self.iterator.processes[self.iterator.index];
             if (process_id == 0) continue;
 
             const name: []const u8 = procblk: {
-                const process_handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, windows.FALSE, process_id) orelse {
+                const process_handle = kernel32.OpenProcess(kernel32.PROCESS_QUERY_LIMITED_INFORMATION, windows.FALSE, process_id) orelse {
                     const win32err = windows.GetLastError();
                     switch (win32err) {
                         // If the specified process is the System process or one of the Client Server Run-Time Subsystem (CSRSS) processes,
@@ -102,7 +143,7 @@ const WindowsProcessList = struct {
                 var name: []u8 = nameblk: {
                     var name_buffer_len: u32 = windows.PATH_MAX_WIDE + 1;
                     var name_buffer: [windows.PATH_MAX_WIDE:0]u16 = undefined;
-                    if (QueryFullProcessImageNameW(process_handle, 0, name_buffer[0..], &name_buffer_len) == 0) {
+                    if (kernel32.QueryFullProcessImageNameW(process_handle, 0, name_buffer[0..], &name_buffer_len) == 0) {
                         const err = windows.GetLastError();
                         switch (err) {
                             // Undocumented in 2025: If we can't do anything with it, just ignore it.
@@ -111,8 +152,8 @@ const WindowsProcessList = struct {
                         }
                     }
                     const name_u16 = name_buffer[0..name_buffer_len :0];
-                    const len = try std.unicode.utf16LeToUtf8(&self.it_exe_filepath, name_u16[0..]);
-                    const name = self.it_exe_filepath[0..len];
+                    const len = try std.unicode.utf16LeToUtf8(&self.exe_filepath_buffer, name_u16[0..]);
+                    const name = self.exe_filepath_buffer[0..len];
                     break :nameblk name;
                 };
 
@@ -122,58 +163,363 @@ const WindowsProcessList = struct {
                 break :procblk name;
             };
 
-            // TODO(jae): 2025-12-20
-            // Explore re-opening process if it's a 'javaw' application and if it has certain modules running, then assume
-            // it is a game. Mostly want to explore this to make Minecraft Java Edition work.
-            //
-            // Initially I used this but this method requires a mix of "PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_VM_READ"
-            // and I'm wary of "PROCESS_VM_READ" being detected by Easy Anti-Cheat.
-            //
-            // if (std.mem.eql(u8, std.fs.path.basenamePosix(name), "javaw")) {
-            //     const java_name: []u8 = nameblk: {
-            //         // Read the first module, which tells us where the application EXE is
-            //         var module_handle: windows.HMODULE = undefined;
-            //         var needed: u32 = 0; // Got: 880 / 4 = 220, so some processes have a *lot* of modules
-            //         if (K32EnumProcessModulesEx(process_handle, &module_handle, @sizeOf(@TypeOf(module_handle)), &needed, LIST_MODULES_ALL) == 0) {
-            //             const err = windows.GetLastError();
-            //             switch (err) {
-            //                 // NOTE(jae): Occurred when running VRChat, might be due to Easy Anti-Cheat?
-            //                 .ACCESS_DENIED => continue,
-            //                 // NOTE(jae): PARTIAL_COPY occurs in some cases and I'm not sure why. I tried switching to 'K32EnumProcessModulesEx' as per: https://stackoverflow.com/a/11134981/5013410
-            //                 // But still no luck. So let's skip this one.
-            //                 .PARTIAL_COPY => continue,
-            //                 else => return windows.unexpectedError(windows.GetLastError()),
-            //             }
-            //          }
-            //
-            //         std.debug.panic("needed: {}", .{needed});
-            //
-            //         var name_buffer: [windows.PATH_MAX_WIDE + 4:0]u16 = undefined;
-            //         // GetModuleFileNameExW requires this prefix to be present
-            //         @memcpy(name_buffer[0..4], &[_]u16{ '\\', '?', '?', '\\' });
-            //
-            //         // Get path and then convert to utf-8
-            //         const len_u16 = windows.kernel32.GetModuleFileNameExW(process_handle, module_handle, @ptrCast(&name_buffer[4]), windows.PATH_MAX_WIDE);
-            //         const name_u16 = name_buffer[0 .. len_u16 + 4 :0];
-            //         const len = try std.unicode.utf16LeToUtf8(&self.it_exe_filepath, name_u16[4..]);
-            //         const java_name = self.it_exe_filepath[0..len];
-            //         // TODO: Detect prefix of '//?/' that occurs specifically for 'C:/WINDOWS/system32/conhost' only seemingly and remove it
-            //         break :nameblk java_name;
-            //     };
-            //     @panic(java_name);
-            // }
+            // If we retrieved arguments last time, free the memory
+            if (self.iterator.command_line_arguments.len > 0) {
+                self.iterator.allocator.free(self.iterator.command_line_arguments);
+                self.iterator.command_line_arguments = &[0]u8{};
+            }
 
-            self.index += 1;
+            // If a Java application, extract command-line arguments so we can inspect and know what application was launched
+            if (std.mem.eql(u8, std.fs.path.basenamePosix(name), "javaw")) {
+                self.iterator.command_line_arguments = try self.wmi.getCommandLineArguments(self.iterator.allocator, process_id);
+            }
+
+            self.iterator.index += 1;
             return .{
                 .exe_filepath = name,
+                .jar_arguments = self.iterator.command_line_arguments,
             };
         }
         return null;
     }
 
     fn close(self: *@This()) void {
-        self.* = undefined;
+        if (self.iterator.command_line_arguments.len > 0) {
+            self.iterator.allocator.free(self.iterator.command_line_arguments);
+            self.iterator.command_line_arguments = &[0]u8{};
+        }
+        self.iterator = .empty;
     }
+
+    const Wmi = struct {
+        services: ?*wbemuuid.IWbemServices,
+        /// Is UTF-16 string of "WQL" in BSTR format.
+        /// ie. SysAllocString(utf8ToUtf16LeStringLiteral("WQL"))
+        language: windows.BSTR,
+        /// Is UTF-16 string of the process list query, ie. "SELECT CommandLine FROM Win32_Process where ProcessId = 4294967295"
+        query: *[QueryProcessMaxBuffer.len:0]windows.WCHAR,
+
+        const none: Wmi = .{
+            .services = null,
+            .language = undefined,
+            .query = undefined,
+        };
+
+        const QueryProcess = "SELECT CommandLine FROM Win32_Process where ProcessId = {}";
+
+        /// Appending '4294967295' allows fitting the largest uint32 in string format (4294967295) and then some in our query when we modify
+        /// it and then pad it out with spaces.
+        const QueryProcessMaxBuffer = std.unicode.utf8ToUtf16LeStringLiteral(QueryProcess ++ "4294967295");
+
+        fn init(self: *@This()) !void {
+            // Initialize COM
+            {
+                var co_init_ex_hr = ole32.CoInitializeEx(null, ole32.COINIT_APARTMENTTHREADED);
+                if (co_init_ex_hr == ole32.RPC_E_CHANGED_MODE) {
+                    // If a previous call to CoInitializeEx specified an incompatible concurrency model for this thread, do it
+                    // as COINIT_MULTITHREADED.
+                    //
+                    // Copies logic from SDL_windows.c
+                    co_init_ex_hr = ole32.CoInitializeEx(null, ole32.COINIT_MULTITHREADED);
+                }
+                // - S_FALSE = The COM library is already initialized on this thread. Still requires calling "CoUninitialize"
+                if (co_init_ex_hr != windows.S_OK and co_init_ex_hr != windows.S_FALSE) return windows.unexpectedError(windows.HRESULT_CODE(co_init_ex_hr));
+            }
+            errdefer ole32.CoUninitialize();
+
+            // Init CoInitializeSecurity
+            {
+                const hr = ole32.CoInitializeSecurity(null, -1, null, null, ole32.RPC_C_AUTHN_LEVEL_DEFAULT, ole32.RPC_C_IMP_LEVEL_IMPERSONATE, null, ole32.EOAC_NONE, null);
+                if (hr != windows.S_OK) return windows.unexpectedError(windows.HRESULT_CODE(hr));
+            }
+
+            // Connect to WMI
+            // https://learn.microsoft.com/en-us/windows/win32/wmisdk/example-creating-a-wmi-application
+            const locator: *wbemuuid.IWbemLocator = hrblk: {
+                var result: *wbemuuid.IWbemLocator = undefined;
+                const hr = ole32.CoCreateInstance(&wbemuuid.CLSID_WbemLocator, null, ole32.CLSCTX_INPROC_SERVER, &wbemuuid.IID_IWbemLocator, @ptrCast(&result));
+                if (hr != windows.S_OK) return windows.unexpectedError(windows.HRESULT_CODE(hr));
+                break :hrblk result;
+            };
+            errdefer _ = locator.lpVtbl.*.Release.?(locator);
+
+            // BSTR strings we'll use (http://msdn.microsoft.com/en-us/library/ms221069.aspx)
+            const language: windows.BSTR = try ole32.SysAllocString(std.unicode.utf8ToUtf16LeStringLiteral("WQL"));
+            errdefer ole32.SysFreeString(language);
+
+            // NOTE(jae): 2025-12-22
+            // Allocate the query string once at the start, then just modify the string query,
+            // filling the end of it with spaces so that the prefixed-length of the BSTR doesn't need to change.
+            const query_raw = try ole32.SysAllocString(QueryProcessMaxBuffer);
+            errdefer ole32.SysFreeString(query_raw);
+            const query: *[QueryProcessMaxBuffer.len:0]windows.WCHAR = query_raw[0..QueryProcessMaxBuffer.len :0];
+
+            const services: *wbemuuid.IWbemServices = hrblk: {
+                const resource: windows.BSTR = try ole32.SysAllocString(std.unicode.utf8ToUtf16LeStringLiteral("ROOT\\CIMV2"));
+                defer ole32.SysFreeString(resource);
+
+                var r: *wbemuuid.IWbemServices = undefined;
+                const hr = locator.lpVtbl.*.ConnectServer.?(locator, resource, null, null, null, 0, null, null, @ptrCast(&r));
+                if (hr != windows.S_OK) return windows.unexpectedError(windows.HRESULT_CODE(hr));
+                break :hrblk r;
+            };
+            errdefer _ = services.lpVtbl.*.Release.?(services);
+
+            self.* = .{
+                .services = services,
+                .language = language,
+                .query = query,
+            };
+        }
+
+        fn deinit(self: *@This()) void {
+            assert(self.services != null);
+            if (self.services) |services| {
+                _ = services.lpVtbl.*.Release.?(services);
+            }
+            ole32.SysFreeString(self.language);
+            ole32.SysFreeString(self.query);
+            ole32.CoUninitialize();
+            self.* = undefined;
+        }
+
+        fn getCommandLineArguments(self: *@This(), allocator: std.mem.Allocator, process_id: windows.DWORD) ![]const u8 {
+            const services = self.services orelse {
+                return error.Unexpected;
+            };
+
+            // Replace existing UTF-16 query string with process id
+            // and pad the end of the string with spaces to avoid changing the allocated length.
+            // (BSTR is NOT a null-terimated UTF-16 string, it has a prefix that describes the slice length)
+            {
+                var buf_data: [QueryProcessMaxBuffer.len]u8 = undefined;
+                const buf = try std.fmt.bufPrint(buf_data[0..], QueryProcess, .{process_id});
+                const next_char = try std.unicode.utf8ToUtf16Le(self.query[0..], buf);
+                for (self.query[next_char..]) |*c| {
+                    c.* = ' ';
+                }
+            }
+
+            // Issue a WMI query
+            const results: *wbemuuid.IEnumWbemClassObject = hrblk: {
+                var r: *wbemuuid.IEnumWbemClassObject = undefined;
+                const hr = services.lpVtbl.*.ExecQuery.?(services, self.language, self.query, wbemuuid.WBEM_FLAG_FORWARD_ONLY, null, @ptrCast(&r));
+                if (hr != windows.S_OK) return windows.unexpectedError(windows.HRESULT_CODE(hr));
+                break :hrblk r;
+            };
+            defer _ = results.lpVtbl.*.Release.?(results);
+
+            // Enumerate the retrieved objects
+            while (true) {
+                const ms_wait = 5000;
+
+                // Get next item
+                // https://learn.microsoft.com/en-us/windows/win32/api/wbemcli/nf-wbemcli-ienumwbemclassobject-next
+                var result: *wbemuuid.IWbemClassObject = undefined;
+                var returned_count: windows.ULONG = 0;
+                {
+                    const hr = results.lpVtbl.*.Next.?(results, ms_wait, 1, @ptrCast(&result), &returned_count);
+                    if (hr != windows.S_OK) break;
+                }
+                defer _ = result.lpVtbl.*.Release.?(result);
+                if (returned_count == 0) break;
+
+                // Get 'CommandLine' value
+                //
+                // Example outputs:
+                // - .\.zig-cache\o\d21ec2a994a87d3d01f6126afdfc2140\desk-breaker.exe
+                // - C:\zig\current\zig.exe build run
+                // - \??\C:\WINDOWS\system32\conhost.exe 0x4
+                // - "C:\Program Files\Git\bin\..\usr\bin\bash.exe" --init-file "c:\Microsoft VS Code\resources\app/out/vs/workbench/contrib/terminal/common/scripts/shellIntegration-bash.sh"
+                // - exe: "C:\Microsoft VS Code\Code.exe" --type=utility --utility-sub-type=node.mojom.NodeService
+                var column: wbemuuid.VARIANT = undefined;
+                {
+                    const hr = result.lpVtbl.*.Get.?(result, std.unicode.utf8ToUtf16LeStringLiteral("CommandLine"), 0, &column, 0, 0);
+                    if (hr != windows.S_OK) return windows.unexpectedError(windows.HRESULT_CODE(hr));
+                }
+                const column_ptr = column.unnamed_0.unnamed_0.unnamed_0.bstrVal;
+                if (column_ptr == null) continue;
+                const column_length = ole32.SysStringLen(column_ptr);
+                const exe_and_command_line = column_ptr[0..column_length];
+
+                // Skip the program application path, do this before allocating a new UTF-8 string to lower the size of the memory being allocated.
+                const command_line_args_start_index: usize = findexeblk: {
+                    var it = std.unicode.Utf16LeIterator.init(exe_and_command_line);
+                    // Iterate until we find '.exe' so we can *only* get the characters after the filepath
+                    lexblk: while (try it.nextCodepoint()) |char| {
+                        // If not .exe, then continue searching
+                        if (char != '.') continue;
+                        if (try it.nextCodepoint() != 'e') continue;
+                        if (try it.nextCodepoint() != 'x') continue;
+                        if (try it.nextCodepoint() != 'e') continue;
+
+                        while (try it.nextCodepoint()) |next_char| {
+                            if (next_char != ' ') continue;
+                            break :lexblk;
+                        }
+                        break :lexblk;
+                    }
+                    if (it.i == 0) break :findexeblk it.i; // Avoid div by 0
+                    break :findexeblk it.i / 2; // Convert u8 index into u16 index
+                };
+                const command_line_args_utf16 = exe_and_command_line[command_line_args_start_index..];
+                if (command_line_args_utf16.len == 0) continue;
+
+                const command_line_args = try std.unicode.utf16LeToUtf8Alloc(allocator, command_line_args_utf16);
+                errdefer allocator.free(command_line_args);
+
+                return command_line_args;
+            }
+            return &[0]u8{};
+        }
+    };
+};
+
+const LinuxProcessList = struct {
+    allocator: std.mem.Allocator,
+    proc: ?Dir,
+    it: Dir.Iterator,
+    it_exe_filepath_buf: [std.fs.max_path_bytes + 32:0]u8,
+    it_exe_and_args_buf: []u8,
+
+    fn init(self: *@This()) !void {
+        self.* = .{
+            .proc = null,
+            .it_exe_and_args_buf = &[0]u8{},
+            .allocator = undefined,
+            .it = undefined,
+            .it_exe_filepath_buf = undefined,
+        };
+    }
+
+    fn deinit(self: *@This()) void {
+        // If forgot to call 'close' this will catch an issue
+        assert(self.it_exe_and_args_buf.len == 0);
+        assert(self.proc == null);
+    }
+
+    fn open(self: *@This(), allocator: std.mem.Allocator) OpenError!void {
+        var proc = std.fs.openDirAbsolute("/proc", .{
+            .iterate = true,
+        }) catch |err| switch (err) {
+            error.AccessDenied => return error.AccessDenied,
+            error.FileNotFound => return error.AccessDenied,
+            else => unreachable,
+        };
+        const it = proc.iterate();
+
+        assert(self.it_exe_and_args_buf.len == 0);
+        self.* = .{
+            .allocator = allocator,
+            .proc = proc,
+            .it = it,
+            .it_exe_filepath_buf = undefined,
+            .it_exe_and_args_buf = &[0]u8{},
+        };
+    }
+
+    /// Borrowed how to get process list from this: https://stackoverflow.com/a/3797621
+    /// Tested on Bazzite/KDE.
+    fn next(self: *@This()) !?Entry {
+        const proc = self.proc orelse {
+            return error.Unexpected;
+        };
+        var proc_pid_info_buf: [64]u8 = undefined;
+        entryloop: while (try self.it.next()) |entry| {
+            if (entry.name.len >= 1 and entry.name[0] >= '0' and entry.name[0] <= '9') {
+                const proc_exe_path = try std.fmt.bufPrintZ(proc_pid_info_buf[0..], "{s}/exe", .{entry.name});
+                const filepath = proc.readLinkZ(proc_exe_path, self.it_exe_filepath_buf[0..]) catch |err| switch (err) {
+                    // Ignore processes that
+                    // - We don't have access to
+                    // - That were closed / no longer exist
+                    error.AccessDenied, error.FileNotFound => continue :entryloop,
+                    else => return err,
+                };
+                const basename = std.fs.path.basename(filepath);
+
+                const jar_arguments: []const u8 = argblk: {
+                    if (!std.mem.eql(u8, basename, "java")) {
+                        break :argblk &[0]u8{};
+                    }
+
+                    // If we set 'jar_arguments' on the last iteration, free the buffer
+                    self.freeExeAndArgsIfSet();
+
+                    // If Java application, then extract the argument contains references to '.jar' files
+                    const proc_args = try std.fmt.bufPrintZ(proc_pid_info_buf[0..], "{s}/cmdline", .{entry.name});
+                    const allocator = self.allocator;
+                    self.it_exe_and_args_buf = proc.readFileAlloc(allocator, proc_args, 2_097_152) catch |err| switch (err) {
+                        // Ignore processes that
+                        // - We don't have access to
+                        // - That were closed / no longer exist
+                        error.AccessDenied, error.FileNotFound => continue :entryloop,
+                        else => return err,
+                    };
+                    errdefer {
+                        allocator.free(self.it_exe_and_args_buf);
+                        self.it_exe_and_args_buf = &[0]u8{};
+                    }
+                    const after_exe_path_index = std.mem.indexOfScalar(u8, self.it_exe_and_args_buf, '\x00') orelse {
+                        allocator.free(self.it_exe_and_args_buf);
+                        self.it_exe_and_args_buf = &[0]u8{};
+                        break :argblk &[0]u8{};
+                    };
+                    const args = self.it_exe_and_args_buf[after_exe_path_index + 1 ..];
+                    std.mem.replaceScalar(u8, args, '\x00', ' ');
+                    break :argblk args;
+                };
+                return .{
+                    .exe_filepath = filepath,
+                    .jar_arguments = jar_arguments,
+                };
+            }
+        }
+        return null;
+    }
+
+    fn close(self: *@This()) void {
+        self.freeExeAndArgsIfSet();
+        if (self.proc) |*proc| {
+            proc.close();
+        }
+    }
+
+    fn freeExeAndArgsIfSet(self: *@This()) void {
+        if (self.it_exe_and_args_buf.len > 0) {
+            const allocator = self.allocator;
+            allocator.free(self.it_exe_and_args_buf);
+            self.it_exe_and_args_buf = &[0]u8{};
+        }
+    }
+};
+
+const DummyProcessList = struct {
+    fn init(_: *@This()) !void {}
+
+    fn deinit(_: *@This()) void {}
+
+    fn open(_: *@This(), _: std.mem.Allocator) OpenError!void {
+        @compileError("Do not call open() as target is not supported. Check with 'isSupported' first.");
+    }
+
+    fn next(_: *@This()) !?Entry {
+        @compileError("Do not call next() as target is not supported. Check with 'isSupported' first.");
+    }
+
+    fn close(_: *@This()) void {
+        @compileError("Do not call close() as target is not supported. Check with 'isSupported' first.");
+    }
+};
+
+const kernel32 = struct {
+    const windows = std.os.windows;
+    const DWORD = windows.DWORD;
+    const UINT = windows.UINT;
+    const WCHAR = windows.WCHAR;
+    const CHAR = windows.CHAR;
+    const BOOL = windows.BOOL;
+
+    pub extern "kernel32" fn WideCharToMultiByte(CodePage: UINT, dwFlags: DWORD, lpWideCharStr: [*c]const WCHAR, cchWideChar: c_int, lpMultiByteStr: [*c]CHAR, cbMultiByte: c_int, lpDefaultChar: [*c]const CHAR, lpUsedDefaultChar: [*c]BOOL) callconv(.winapi) c_int;
 
     /// [out] lpidProcess: A pointer to an array that receives the list of process identifiers.
     /// [in]  cb: The size of the pProcessIds array, in bytes.
@@ -216,67 +562,127 @@ const WindowsProcessList = struct {
     extern "kernel32" fn K32EnumProcessModulesEx(hProcess: windows.HANDLE, lphModule: ?*windows.HMODULE, cb: windows.DWORD, lpcbNeeded: ?*u32, dwFilterFlag: windows.DWORD) callconv(.winapi) windows.BOOL;
 };
 
-const LinuxProcessList = struct {
-    proc: Dir,
-    it: Dir.Iterator,
-    it_exe_filepath: [std.fs.max_path_bytes:0]u8 = undefined,
+const ole32 = struct {
+    const windows = std.os.windows;
+    const LPVOID = windows.LPVOID;
+    const DWORD = windows.DWORD;
+    const HRESULT = windows.HRESULT;
+    const OLECHAR = u16;
+    const BSTR = windows.BSTR;
+    const UINT = windows.UINT;
+    const GUID = windows.GUID;
 
-    fn open() OpenError!@This() {
-        var proc = std.fs.openDirAbsolute("/proc", .{
-            .iterate = true,
-        }) catch |err| switch (err) {
-            error.AccessDenied => return error.AccessDenied,
-            error.FileNotFound => return error.AccessDenied,
-            else => unreachable,
-        };
-        const it = proc.iterate();
-        return .{
-            .proc = proc,
-            .it = it,
-            .it_exe_filepath = undefined,
-        };
-    }
+    pub const COINIT_APARTMENTTHREADED: DWORD = 2;
+    pub const COINIT_MULTITHREADED: DWORD = 0;
+    pub const COINIT_DISABLE_OLE1DDE: DWORD = 4;
+    pub const COINIT_SPEED_OVER_MEMORY: DWORD = 8;
 
-    /// Borrowed how to get process list from this: https://stackoverflow.com/a/3797621
-    /// Tested on Bazzite/KDE.
-    fn next(self: *@This()) !?Entry {
-        var buf_path: [64]u8 = undefined;
-        while (try self.it.next()) |entry| {
-            if (entry.name.len >= 1 and entry.name[0] >= '0' and entry.name[0] <= '9') {
-                const proc_exe_path = try std.fmt.bufPrintZ(buf_path[0..], "{s}/exe", .{entry.name});
-                const filepath = self.proc.readLinkZ(proc_exe_path, self.it_exe_filepath[0..]) catch |err| switch (err) {
-                    // Ignore processes that
-                    // - We don't have access to
-                    // - That were closed / no longer exist
-                    error.AccessDenied, error.FileNotFound => continue,
-                    else => return err,
-                };
-                return .{
-                    .exe_filepath = filepath,
-                };
-            }
-        }
-        return null;
-    }
+    pub const RPC_E_CHANGED_MODE: c_long = -0x7FFEFEFA; // ie. 0x80010106;
 
-    fn close(self: *@This()) void {
-        self.proc.close();
-        self.* = undefined;
+    pub const EOAC_NONE: c_int = 0;
+
+    pub const RPC_C_AUTHN_LEVEL_DEFAULT: c_int = 0;
+    pub const RPC_C_IMP_LEVEL_IMPERSONATE: c_int = 3;
+
+    pub const CLSCTX_INPROC_SERVER: c_int = 1;
+
+    pub const SOLE_AUTHENTICATION_SERVICE = extern struct {
+        dwAuthnSvc: DWORD = 0,
+        dwAuthzSvc: DWORD = 0,
+        pPrincipalName: [*c]OLECHAR = std.mem.zeroes([*c]OLECHAR),
+        hr: HRESULT = 0,
+    };
+
+    pub extern "ole32" fn CoInitializeEx(pvReserved: ?*anyopaque, dwCoInit: DWORD) HRESULT;
+    pub extern "ole32" fn CoUninitialize() callconv(.winapi) void;
+    pub extern "ole32" fn CoInitializeSecurity(pSecDesc: ?*anyopaque, cAuthSvc: c_long, asAuthSvc: [*c]SOLE_AUTHENTICATION_SERVICE, pReserved1: ?*anyopaque, dwAuthnLevel: DWORD, dwImpLevel: DWORD, pAuthList: ?*anyopaque, dwCapabilities: DWORD, pReserved3: ?*anyopaque) callconv(.winapi) HRESULT;
+    pub extern "ole32" fn CoCreateInstance(rclsid: *const GUID, pUnkOuter: ?*unknwn.IUnknown, dwClsContext: DWORD, riid: *const GUID, ppv: ?*anyopaque) callconv(.winapi) HRESULT;
+
+    pub fn SysAllocString(str: [*c]const OLECHAR) error{OutOfMemory}!BSTR {
+        const r = oleaut32.SysAllocString(str);
+        if (str != null and r == null) return error.OutOfMemory;
+        return r;
     }
+    pub extern "oleaut32" fn SysFreeString(BSTR) callconv(.winapi) void;
+    pub extern "oleaut32" fn SysStringLen(BSTR) callconv(.winapi) UINT;
+
+    const oleaut32 = struct {
+        /// If successful, returns the string. If psz is a zero-length string, returns a zero-length BSTR.
+        /// If psz is NULL or insufficient memory exists, returns NULL.
+        pub extern "oleaut32" fn SysAllocString([*c]const OLECHAR) [*c]windows.WCHAR;
+    };
+
+    pub const CP_UTF8: c_long = 65001;
+
+    // https://stackoverflow.com/a/52000515/5013410
+    // pub fn bstrToUtf8(allocator: std.mem.Allocator, bstr: [*c]windows.WCHAR) error{ OutOfMemory, InvalidParameter, Unexpected }![:0]const u8 {
+    //     if (bstr == null) return &[0:0]u8{};
+    //     const len = SysStringLen(bstr);
+    //     // special case because a NULL BSTR is a valid zero-length BSTR,
+    //     // but regular string functions would balk on it
+    //     if (len == 0) return &[0:0]u8{};
+    //     const size_needed = kernel32.WideCharToMultiByte(CP_UTF8, 0, bstr, @intCast(len), null, 0, null, null);
+    //     if (size_needed == 0) {
+    //         const win32err = windows.GetLastError();
+    //         switch (win32err) {
+    //             .INVALID_PARAMETER => return error.InvalidParameter,
+    //             else => return windows.unexpectedError(win32err),
+    //         }
+    //     }
+    //     const ret = try allocator.allocSentinel(u8, @intCast(size_needed), 0);
+    //     if (kernel32.WideCharToMultiByte(CP_UTF8, 0, bstr, @intCast(len), ret.ptr, @intCast(ret.len), null, null) == 0) {
+    //         const win32err = windows.GetLastError();
+    //         switch (win32err) {
+    //             .INVALID_PARAMETER => return error.InvalidParameter,
+    //             else => return windows.unexpectedError(win32err),
+    //         }
+    //     }
+    //     return ret;
+    // }
 };
 
-const DummyProcessList = struct {
-    fn open() OpenError!@This() {
-        @compileError("Do not call open() as target is not supported. Check with 'isSupported' first.");
-    }
+/// https://learn.microsoft.com/en-us/windows/win32/api/unknwn/
+pub const unknwn = struct {
+    const windows = std.os.windows;
 
-    fn next(_: *@This()) !?Entry {
-        @compileError("Do not call next() as target is not supported. Check with 'isSupported' first.");
-    }
+    pub const QueryInterface = *const fn (*IUnknown, *const windows.GUID, [*c]?*anyopaque) callconv(.c) windows.HRESULT;
+    pub const AddRef = *const fn (*IUnknown, *const windows.GUID, [*c]?*anyopaque) callconv(.c) windows.HRESULT;
+    pub const Release = **const fn (*IUnknown) callconv(.c) windows.ULONG;
 
-    fn close(_: *@This()) void {
-        @compileError("Do not call close() as target is not supported. Check with 'isSupported' first.");
-    }
+    /// https://learn.microsoft.com/en-us/windows/win32/api/unknwn/nn-unknwn-iunknown
+    pub const IUnknown = extern struct {
+        vtbl: ?*VTable,
+
+        pub const VTable = extern struct {
+            QueryInterface: QueryInterface,
+            AddRef: AddRef,
+            Release: Release,
+        };
+    };
+};
+
+pub const wbemuuid = struct {
+    const windows = std.os.windows;
+
+    /// The IWbemServices interface is used by clients and providers to access WMI services. The interface is implemented by WMI and WMI providers, and is the primary WMI interface.
+    const c = @cImport({
+        @cDefine("WIN32_LEAN_AND_MEAN", "1");
+        @cDefine("_WIN32_WINNT", "0x0400");
+        @cDefine("_WIN32_DCOM", "1");
+        @cInclude("wbemcli.h");
+    });
+
+    pub const WBEM_FLAG_FORWARD_ONLY: c_int = 32;
+
+    pub extern "wbemuuid" const CLSID_WbemLocator: windows.GUID;
+    pub extern "wbemuuid" const IID_IWbemLocator: windows.GUID;
+
+    pub const IWbemLocator = c.IWbemLocator;
+    pub const IWbemServices = c.IWbemServices;
+    pub const IEnumWbemClassObject = c.IEnumWbemClassObject;
+    pub const IWbemClassObject = c.IWbemClassObject;
+
+    pub const VARIANT = c.VARIANT;
 };
 
 const Self = @This();


### PR DESCRIPTION
**Changelog**
- Update Linux implementation to return program arguments if the application is "java", this is so we can detect if the game is Minecraft  or Starsector (untested)
- Update Windows implementation to return program arguments if the application is "javaw", so we can detect if the game is Minecraft or Starsector (untested)
- Update Dolphin emulator detection on Linux

📕 Resources used:
- Get process command-line arguments with COM+WMI: https://stackoverflow.com/a/78889953 
- Calling COM functions from C (no C++): https://stackoverflow.com/a/1431517